### PR TITLE
Fix use after free in iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,8 +616,12 @@ impl<K: Ord, V> Iterator for IntoIter<K, V> {
         }
 
         let next = self.head.next();
-        let obj = unsafe { Box::from_raw(self.head.0) };
-        let (k, v) = obj.pair();
+        let (k, v) = unsafe {
+            (
+                core::ptr::read(&(*self.head.0).key),
+                core::ptr::read(&(*self.head.0).value),
+            )
+        };
         self.head = next;
         self.len -= 1;
         Some((k, v))


### PR DESCRIPTION
The Box::from_raw call causes the pointer to be deallocated once the Box
is dropped, so when the next call attempts to run self.head.next(), it
does a use after free. Non-destructively reading the key and value fixes
this.