### PR TITLE
Removed wrong check in next_back method for DoubleEndedIterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,10 +717,6 @@ impl<'a, K: Ord + 'a, V: 'a> DoubleEndedIterator for Iter<'a, K, V> {
             return None;
         }
 
-        if self.tail == self.head {
-            return None;
-        }
-
         let (k, v) = unsafe { (&(*self.tail.0).key, &(*self.tail.0).value) };
         self.tail = self.tail.prev();
         self.len -= 1;


### PR DESCRIPTION
Exiting the iteration by returning `None` when `self.head == self.tail` leads to the first element not being printed. This happens because we iterate in the opposite direction and always set self.tail = self.tail.prev(). At the last iteration self.head will be the same as self.tail and we should return that node not 'None'. We should only exit the iteration when len is 0.

Example
```
self.memtable.insert(1);
self.memtable.insert(2);
self.memtable.insert(3);
self.memtable.insert(4);

 let elements = self.memtable
            .iter()
            .rev()

for e in elements {
 println!("Element, {:?}", e)
}
```
This will print all elements aside 1,  by removing the extra check `self.head==self.tail` in next_back method,  all the elements are printed.

